### PR TITLE
Feature update many

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,11 +109,15 @@ async def test_update_multiple(test_config):
         item = await items.create_one({"index": index})
         created.append(item)
 
+    count = 0
     async for updated in items.update_many(
         {"index": {"$gte": 4}}, {"description": "Hello there how are you?"}
     ):
+        count += 1
         assert updated.description == "Hello there how are you?"
         assert await items.find_one_by_id(updated.id) == updated
+
+    assert count == 7
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,7 +110,7 @@ async def test_update_multiple(test_config):
         created.append(item)
 
     async for updated in items.update_many(
-        {"index": {"$ge": 4}}, {"description": "Hello there how are you?"}
+        {"index": {"$gte": 4}}, {"description": "Hello there how are you?"}
     ):
         assert updated.description == "Hello there how are you?"
         assert await items.find_one_by_id(updated.id) == updated

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -93,6 +93,30 @@ async def test_update(test_config):
 
 
 @pytest.mark.asyncio
+async def test_update_multiple(test_config):
+    class Item(BaseDocument):
+        index: int
+        description: Optional[str]
+
+    await Client.initialize(
+        mongo_url=test_config.mongo_url, mongo_database=test_config.mongo_database
+    )
+
+    items = Client().use(Item)
+
+    created = []
+    for index in range(10):
+        item = await items.create_one({"index": index})
+        created.append(item)
+
+    async for updated in items.update_many(
+        {"index": {"$ge": 4}}, {"description": "Hello there how are you?"}
+    ):
+        assert updated.description == "Hello there how are you?"
+        assert await items.find_one_by_id(updated.id) == updated
+
+
+@pytest.mark.asyncio
 async def test_multiple_documents(test_config):
     class Product(BaseDocument):
         title: str

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -117,7 +117,7 @@ async def test_update_multiple(test_config):
         assert updated.description == "Hello there how are you?"
         assert await items.find_one_by_id(updated.id) == updated
 
-    assert count == 7
+    assert count == 6
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,13 +110,14 @@ async def test_update_multiple(test_config):
         created.append(item)
 
     count = 0
+    # Update index >= 4, which will be 6 (4 5 6 7 8 9)
     async for updated in items.update_many(
         {"index": {"$gte": 4}}, {"description": "Hello there how are you?"}
     ):
         count += 1
         assert updated.description == "Hello there how are you?"
         assert await items.find_one_by_id(updated.id) == updated
-
+    # Verify the number updated
     assert count == 6
 
 

--- a/vanmongo/collection.py
+++ b/vanmongo/collection.py
@@ -347,7 +347,7 @@ class Collection(Generic[TDocument]):
         """
         cursor = self.collection.find(query)
         async for raw in cursor:
-            document_id = raw['id']
+            document_id = raw["id"]
             updated_document = await self.update_one(
                 query={"id": document_id}, update=update
             )

--- a/vanmongo/collection.py
+++ b/vanmongo/collection.py
@@ -338,6 +338,21 @@ class Collection(Generic[TDocument]):
 
         return updated_document
 
+    async def update_many(
+        self, query: Dict[str, Any], update: Dict[str, Any] = {}
+    ) -> AsyncGenerator[TDocument, None]:
+        """
+        Update multiple documents based on the query
+        Works similar to db.collection.updateMany() in MongoDB
+        """
+        cursor = self.collection.find(query)
+        async for raw in cursor:
+            document_id = raw['id']
+            updated_document = await self.update_one(
+                query={"id": document_id}, update=update
+            )
+            yield updated_document
+
     async def update_one_by_id(self, id: str, update: Dict[str, Any] = {}):
         """Update a document with specific ID"""
         return await self.update_one({"id": id}, update)


### PR DESCRIPTION
- Allow update multiple
- Yield update documents as async generator
```python
await collection.update_many(query, update)

# OR

async for document in collection.update_many(query, update):
    pass
```
- Added test